### PR TITLE
change hugging-face hub module with hotfix issue

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -34,8 +34,9 @@ RUN echo "$(python -c 'import torch; print(torch.version.cuda)')"
 
 RUN pip install fastapi==0.110.0 \
         vllm==0.4.0 \
-        huggingface-hub==0.22.2 \
-        runpod==1.6.2
+        git+https://github.com/huggingface/huggingface_hub@2186-fix-safetensors-info \
+        runpod==1.6.2 \
+        flash-attn==2.5.6
 
 RUN echo "$(pip list | grep torch)"
 RUN echo "$(python -c 'import torch; print(torch.version.cuda)')"
@@ -74,7 +75,7 @@ ENV TRANSFORMERS_CACHE="/runpod-volume/huggingface-cache/hub"
 # Download the models
 RUN mkdir -p /model
 
-COPY docker-entrypoint.sh /docker-entrypoint.sh
+COPY docker-entrypoint.sh docker-entrypoint.sh
 
 # Set environment variables
 ENV PORT=80 \
@@ -90,7 +91,8 @@ RUN if [ "$DOWNLOAD_MODEL" = "1" ]; then \
 
 EXPOSE 8000 6379 80
 
-ENTRYPOINT ["/docker-entrypoint.sh"]
+
+ENTRYPOINT ["docker-entrypoint.sh"]
 
 # Start the handler
 #CMD STREAMING=$STREAMING MODEL_NAME=$MODEL_NAME MODEL_BASE_PATH=$MODEL_BASE_PATH TOKENIZER=$TOKENIZER python -u /handler.py 


### PR DESCRIPTION
Problem: huggingface-hub is with an error on their client-side. Issue opened on huggingface [here](https://github.com/huggingface/huggingface_hub/issues/2186).
Solution: use hoitfix created, obtained from this [stackoverflow](https://stackoverflow.com/questions/78262292/error-loading-hugging-face-model-safetensorsinfo-init-got-an-unexpected-k)

Log 

```
2024-04-02T16:14:14.804483160Z INFO 04-02 16:14:14 selector.py:21] Using XFormers backend.
2024-04-02T16:14:17.168214411Z Traceback (most recent call last):
2024-04-02T16:14:17.168251874Z   File "//handler.py", line 56, in <module>
2024-04-02T16:14:17.168498024Z     llm = AsyncLLMEngine.from_engine_args(engine_args)
2024-04-02T16:14:17.168518894Z   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 348, in from_engine_args
2024-04-02T16:14:17.168524739Z     engine = cls(
2024-04-02T16:14:17.168529699Z   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 311, in __init__
2024-04-02T16:14:17.168534758Z     self.engine = self._init_engine(*args, **kwargs)
2024-04-02T16:14:17.168539861Z   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/async_llm_engine.py", line 422, in _init_engine
2024-04-02T16:14:17.168544211Z     return engine_class(*args, **kwargs)
2024-04-02T16:14:17.168549874Z   File "/usr/local/lib/python3.10/dist-packages/vllm/engine/llm_engine.py", line 111, in __init__
2024-04-02T16:14:17.168554338Z     self.model_executor = executor_class(model_config, cache_config,
2024-04-02T16:14:17.168558927Z   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/gpu_executor.py", line 37, in __init__
2024-04-02T16:14:17.168580184Z     self._init_worker()
2024-04-02T16:14:17.168585204Z   File "/usr/local/lib/python3.10/dist-packages/vllm/executor/gpu_executor.py", line 66, in _init_worker
2024-04-02T16:14:17.168589988Z     self.driver_worker.load_model()
2024-04-02T16:14:17.168594224Z   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/worker.py", line 107, in load_model
2024-04-02T16:14:17.168831339Z     self.model_runner.load_model()
2024-04-02T16:14:17.168857119Z   File "/usr/local/lib/python3.10/dist-packages/vllm/worker/model_runner.py", line 95, in load_model
2024-04-02T16:14:17.168860827Z     self.model = get_model(
2024-04-02T16:14:17.168863703Z   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/model_loader.py", line 101, in get_model
2024-04-02T16:14:17.168866968Z     model.load_weights(model_config.model, model_config.download_dir,
2024-04-02T16:14:17.168870527Z   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/models/mixtral_quant.py", line 383, in load_weights
2024-04-02T16:14:17.168890558Z     for name, loaded_weight in hf_model_weights_iterator(
2024-04-02T16:14:17.168893643Z   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/weight_utils.py", line 224, in hf_model_weights_iterator
2024-04-02T16:14:17.168896421Z     hf_folder, hf_weights_files, use_safetensors = prepare_hf_model_weights(
2024-04-02T16:14:17.168899471Z   File "/usr/local/lib/python3.10/dist-packages/vllm/model_executor/weight_utils.py", line 168, in prepare_hf_model_weights
2024-04-02T16:14:17.168911180Z     file_list = fs.ls(model_name_or_path, detail=False, revision=revision)
2024-04-02T16:14:17.168913892Z   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/hf_file_system.py", line 283, in ls
2024-04-02T16:14:17.169000660Z     resolved_path = self.resolve_path(path, revision=revision)
2024-04-02T16:14:17.169003576Z   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/hf_file_system.py", line 189, in resolve_path
2024-04-02T16:14:17.169006435Z     repo_and_revision_exist, err = self._repo_and_revision_exist(repo_type, repo_id, revision)
2024-04-02T16:14:17.169010985Z   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/hf_file_system.py", line 126, in _repo_and_revision_exist
2024-04-02T16:14:17.169013732Z     self._api.repo_info(repo_id, revision=revision, repo_type=repo_type)
2024-04-02T16:14:17.169016427Z   File "/usr/local/lib/python3.10/dist-packages/huggingface_hub/utils/_validators.py", line 119, in _inner_fn
2024-04-02T16:14:17.169307792Z     return fn(*args, **kwargs)

```